### PR TITLE
1 commits not linked on changelogmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.5.1 (2022-12-14)
+
+##### Bug Fixes
+
+*  Commits not linked on CHANGELOG.md [#1](https://github.com/iptoux/genchlg/pull/1). ([a4a95c58](https://github.com/iptoux/genchlg/commit/a4a95c58eb4e1ebf61a91a2ecdb6d2d82dc7d01c))
+
 ### 0.5.0 (2022-12-14)
 
 ##### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,3 +1,13 @@
 {
-  "version": "0.5.0"
+  "version": "0.5.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iptoux/genchlg.git"
+  },
+  "author": "Maik Roland <iptoux> Damm",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/iptoux/genchlg/issues"
+  },
+  "homepage": "https://github.com/iptoux/genchlg#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.5.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/iptoux/genchlg.git"


### PR DESCRIPTION
```
changelog --help
``` 
shows us an `-u` flag where you can set an repository. 

For the use of this wrapper we already use the `package.json`, because it holds the current version. This is intended by the developer. I have now extended the `package.json` with the following:

```
  "repository": {
    "type": "git",
    "url": "git+https://github.com/iptoux/genchlg.git"
  },
```

this should now fix the issue, please report if not. You also have to add this in your own `package.json` with own url.